### PR TITLE
Release 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ try {
       email: {
         required: true,
         isEmail: true,
+        errorMessage: 'Your custom error message if field fails the validaton'
       },
       password: {
         required: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pretty-validate",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pretty-validate",
-      "version": "0.1.4",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "validator": "^13.6.0"
@@ -3905,9 +3905,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -8049,9 +8049,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "kleur": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-validate",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "A light validator for node applications with minimalistic validation rules description.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,11 +7,18 @@ import isNumber from './isNumber';
 import isString from './isString';
 import isBoolean from './isBoolean';
 import required from './required';
+import isArray from './isArray';
+import isArrayOfEnums from './isArrayOfEnums';
+import isArrayOfStrings from './isArrayOfStrings';
+import isArrayOfUUIDs from './isArrayOfUUIDs';
+import maxLength from './maxLength';
 
 // Sanitizers
 import toLowerCase from './toLowerCase';
 import toUpperCase from './toUpperCase';
 import toInt from './toInt';
+import toArray from './toArray';
+import toPrefixedUrl from './toPrefixedUrl';
 
 const validatorJS = validatorLib.default;
 
@@ -23,6 +30,11 @@ const validations: any = {
     isString,
     isBoolean,
     required,
+    isArray,
+    isArrayOfEnums,
+    isArrayOfStrings,
+    isArrayOfUUIDs,
+    maxLength,
 
     // validator JS methods
     isISO8601: validatorJS.isISO8601,
@@ -109,6 +121,8 @@ const validations: any = {
     toLowerCase,
     toUpperCase,
     toInt,
+    toArray,
+    toPrefixedUrl,
 
     // validator JS methods
     toFloat: validatorJS.toFloat,

--- a/src/lib/isArray.ts
+++ b/src/lib/isArray.ts
@@ -1,0 +1,3 @@
+export default function isArray(value: any): boolean {
+  return Array.isArray(value);
+}

--- a/src/lib/isArrayOfEnums.ts
+++ b/src/lib/isArrayOfEnums.ts
@@ -1,0 +1,13 @@
+export default function isArrayOfEnums(values: any, possibleVals: any): boolean {
+  const allowedValues = Object.values(possibleVals);
+
+  if (!Array.isArray(values)) {
+    return false;
+  }
+  for (const value of values) {
+    if (allowedValues.indexOf(value) < 0) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/lib/isArrayOfStrings.ts
+++ b/src/lib/isArrayOfStrings.ts
@@ -1,0 +1,11 @@
+export default function isArrayOfStrings(values: any): boolean {
+  if (!Array.isArray(values)) {
+    return false;
+  }
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/lib/isArrayOfUUIDs.ts
+++ b/src/lib/isArrayOfUUIDs.ts
@@ -1,0 +1,12 @@
+export default function isArrayOfUUIDs(values: any): boolean {
+  if (!Array.isArray(values)) {
+    return false;
+  }
+  const regex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
+  for (const value of values) {
+    if (!value || typeof value !== 'string' || !regex.test(value)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/lib/maxLength.ts
+++ b/src/lib/maxLength.ts
@@ -1,0 +1,6 @@
+export default function maxLength(value: any, limit: number): boolean {
+  if (typeof value === 'string' || Array.isArray(value)) {
+    return value.length <= limit;
+  }
+  return false;
+}

--- a/src/lib/toArray.ts
+++ b/src/lib/toArray.ts
@@ -1,0 +1,3 @@
+export default function toArray(value: string): any[] {
+  return Array.isArray(value) ? value : [value];
+}

--- a/src/lib/toPrefixedUrl.ts
+++ b/src/lib/toPrefixedUrl.ts
@@ -1,0 +1,6 @@
+export default function toPrefixedUrl(value: string): string {
+  if (value.startsWith('http://') || value.startsWith('https://')) {
+    return value;
+  }
+  return `https://${value}`;
+}

--- a/src/utils/detailed-error.ts
+++ b/src/utils/detailed-error.ts
@@ -1,5 +1,5 @@
 export default class DetailedError extends Error {
-  public details: Record<string, any>;
+  public details: Record<string, any> | Record<string, any>[];
 
   constructor(message: string, details: object = {}) {
     super(message);

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -274,4 +274,43 @@ describe('Validate Method', () => {
       });
     });
   });
+
+  describe('Errors', () => {
+    it('Should throw valid error with all fields violating rules', () => {
+      const object = {
+        id: '123',
+        name: { james: true },
+        value: 'A',
+        text: '123456',
+      };
+
+      try {
+        validator.validate(object, {
+          id: { required: true, isUUID: true, errorMessage: 'Invalid ID' },
+          name: { required: true, isString: true },
+          value: { required: true, isArray: true, errorMessage: 'This is not an array Johnny' },
+          text: { isString: true, maxLength: 5 },
+          number: { required: true },
+        });
+      } catch (error: any) {
+        expect(error.message).toBe('Some of the fields did not pass validation.');
+        expect(error.details.length).toEqual(5);
+
+        expect(error.details[0].message).toEqual('Invalid ID');
+        expect(error.details[0].field).toEqual('id');
+
+        expect(error.details[1].message).toEqual('Failed validation isString');
+        expect(error.details[1].field).toEqual('name');
+
+        expect(error.details[2].message).toEqual('This is not an array Johnny');
+        expect(error.details[2].field).toEqual('value');
+
+        expect(error.details[3].message).toEqual('Failed validation maxLength');
+        expect(error.details[3].field).toEqual('text');
+
+        expect(error.details[4].message).toEqual('Required value');
+        expect(error.details[4].field).toEqual('number');
+      }
+    });
+  });
 });


### PR DESCRIPTION
## In this release
* New validation rules and sanitizers
* Thrown error structure is now changed to following format:
```
{
  message: string,
  details: [
     {
        field: string, <- the name of the field that has failed the validation
        message: string, <- error message for this failed field 
     }
  ]
}
```